### PR TITLE
Things - include application_id

### DIFF
--- a/src/things_api.py
+++ b/src/things_api.py
@@ -165,6 +165,7 @@ def load_things_streamlit_data_and_config():
                 "Things Network application ID", 
                 value="providence-wl",
                 )
+            config["application_id"] = application_id
             api_key = st.text_input(
                 "Things network API key",
                 type="password",


### PR DESCRIPTION
Include the applicaton ID in the config for The Things Network when when a user specifies a different application.